### PR TITLE
add default CFArray callback allocator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _build
 _tests/
 _tests
 .merlin
+.vscode

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # 0.3 (2021-04-24)
 
+* Fix a bug in the retention of values in CFArrays (@patricoferris)
 * Bump dune version and use opam file autogeneration (@avsm).
 * Install library on non-macOS platforms as an empty archive,
   so that it works better in a monorepo (@avsm).

--- a/lib/cf.ml
+++ b/lib/cf.ml
@@ -121,7 +121,11 @@ module Array = struct
         let n = CArray.length a in
         let p = CArray.start a in
         let open C.CFArray in
-        let cf = create None (coerce (ptr T.typ) (ptr (ptr void)) p) n None in
+        let cf =
+          create None
+            (coerce (ptr T.typ) (ptr (ptr void)) p)
+            n (Some Callback.default)
+        in
         Gc.finalise Type.release cf;
         cf
 

--- a/lib_gen/bindings.ml
+++ b/lib_gen/bindings.ml
@@ -486,6 +486,12 @@ module C (F : Cstubs.FOREIGN) = struct
           @-> typedef (ptr (ptr void)) "const void **"
           @-> returning void))
 
+    module Callback = struct
+      let typ = typedef (ptr void) "const CFArrayCallBacks"
+
+      let default = F.(foreign_value "kCFTypeArrayCallBacks" typ)
+    end
+
     (* CFArrayRef CFArrayCreate (
          CFAllocatorRef allocator,
          const void **values,
@@ -499,7 +505,7 @@ module C (F : Cstubs.FOREIGN) = struct
           (ptr_opt void
           @-> typedef (ptr (ptr void)) "const void **"
           @-> CFIndex.t
-          @-> ptr_opt void
+          @-> ptr_opt Callback.typ
           @-> returning typ))
   end
 end


### PR DESCRIPTION
This PR adds the default [kCFTypeArrayCallBacks](https://developer.apple.com/documentation/corefoundation/1388741-cfarraycreate?language=objc) callback to arrays that will manage the retention of CF types. Without this, arrays created with this function won't retain the values stored in the array which might just disappear before being used -- this is currently the case with `ocaml-fsevents` where [the paths to watch are converted for you](https://github.com/mirage/ocaml-fsevents/blob/main/lib_gen/bindings.ml#L328) but because there is no retention, the strings may just disappear causing segfaults.

I've tested this version of `ocaml-cf` with `ocaml-fsevents` and it seems to fix the segfaulting problem, before the repository was recreated [I had some Github tests](https://github.com/patricoferris/ocaml-fsevents/runs/2180179831) which seem to be all green 🎉 . Would appreciate a double-check of the C types I've added because I'm a bit new to the ctypes library. 