### PR TITLE
Fix rule dependency

### DIFF
--- a/lib_gen/dune
+++ b/lib_gen/dune
@@ -28,7 +28,9 @@
  (targets detect.exe)
  (enabled_if
   (= %{system} macosx))
- (deps detect.c)
+ (deps
+  detect.c
+  (package ctypes))
  (action
   (run %{cc} -I %{ocaml_where} -I %{lib:ctypes:} -o %{targets} %{deps})))
 


### PR DESCRIPTION
Otherwise we get:

```
$ (cd _build/default/lib_gen && /usr/bin/cc -O2 -fno-strict-aliasing -fwrapv -pthread -I /Users/thomas/git/ocaml-cf/_opam/lib/ocaml -I ../../install/default/lib/ctypes -o detect.exe detect.c)
> detect.c:4:10: fatal error: 'ctypes_cstubs_internals.h' file not found
> #include "ctypes_cstubs_internals.h"
>          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
> 1 error generated.
```