### PR TITLE
Remove `base-bytes`

### DIFF
--- a/cf.opam
+++ b/cf.opam
@@ -12,7 +12,6 @@ doc: "https://mirage.github.io/ocaml-cf/"
 bug-reports: "https://github.com/mirage/ocaml-cf/issues"
 depends: [
   "dune" {>= "2.9"}
-  "base-bytes"
   "ctypes" {>= "0.4.0"}
   "ctypes-foreign"
   "odoc" {with-doc}

--- a/dune-project
+++ b/dune-project
@@ -15,7 +15,6 @@
  (description "These bindings use [ctypes](https://github.com/ocamllabs/ocaml-ctypes)
 for type-safe stub generation.")
  (depends
-  base-bytes
   (ctypes (>= "0.4.0"))
   ctypes-foreign))
 


### PR DESCRIPTION
Since 4.02 it is implied anyway and that's also dune's minimal version.