### PR TITLE
fix: remove wrong placement of (package ctypes) in dune file

### DIFF
--- a/lib_gen/dune
+++ b/lib_gen/dune
@@ -28,9 +28,7 @@
  (targets detect.exe)
  (enabled_if
   (= %{system} macosx))
- (deps
-  detect.c
-  (package ctypes))
+ (deps detect.c)
  (action
   (run %{cc} -I %{ocaml_where} -I %{lib:ctypes:} -o %{targets} %{deps})))
 


### PR DESCRIPTION
I'm not sure how dune works, but this patch worked for me:
https://github.com/tweag/opam-nix/issues/86